### PR TITLE
Migrated from CommonSaveFileDialog to System.Windows.Forms dialogs

### DIFF
--- a/src/NxFileViewer/Commands/SaveTitleImageCommand.cs
+++ b/src/NxFileViewer/Commands/SaveTitleImageCommand.cs
@@ -6,7 +6,6 @@ using Emignatik.NxFileViewer.Models.Overview;
 using Emignatik.NxFileViewer.Services.Prompting;
 using Emignatik.NxFileViewer.Utils.MVVM.Commands;
 using Microsoft.Extensions.Logging;
-using Microsoft.WindowsAPICodePack.Dialogs;
 
 namespace Emignatik.NxFileViewer.Commands;
 
@@ -44,20 +43,7 @@ public class SaveTitleImageCommand : CommandBase, ISaveTitleImageCommand
 
 
             var defaultFileName = $"{title.AppName}_({title.Language}).jpg";
-            var filters = new CommonFileDialogFilter[]
-            {
-                new()
-                {
-                    DisplayName = LocalizationManager.Instance.Current.Keys.SaveDialog_ImageFilter,
-                    Extensions =
-                    {
-                        "jpg"
-                    },
-                    ShowExtensions = true
-                }
-            };
-
-            var filePath = _promptService.PromptSaveFile(defaultFileName, LocalizationManager.Instance.Current.Keys.SaveDialog_Title, filters);
+            var filePath = _promptService.PromptSaveFile(defaultFileName, LocalizationManager.Instance.Current.Keys.SaveDialog_Title, "Image Files|*.jpg");
 
             if (filePath == null)
                 return;

--- a/src/NxFileViewer/Services/Prompting/IPromptService.cs
+++ b/src/NxFileViewer/Services/Prompting/IPromptService.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using Microsoft.WindowsAPICodePack.Dialogs;
 
 namespace Emignatik.NxFileViewer.Services.Prompting;
 
@@ -7,5 +6,5 @@ public interface IPromptService
 {
     string? PromptSelectDir(string title);
 
-    string? PromptSaveFile(string defaultFileName, string? title = null, IEnumerable<CommonFileDialogFilter>? filters = null);
+    string? PromptSaveFile(string defaultFileName, string? title = null, string? filters = null);
 }

--- a/src/NxFileViewer/Services/Prompting/PromptService.cs
+++ b/src/NxFileViewer/Services/Prompting/PromptService.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Windows;
+using System.Windows.Forms;
 using Emignatik.NxFileViewer.Localization;
 using Emignatik.NxFileViewer.Settings;
 using Emignatik.NxFileViewer.Tools;
-using Microsoft.WindowsAPICodePack.Dialogs;
 
 namespace Emignatik.NxFileViewer.Services.Prompting;
 
@@ -22,55 +20,37 @@ public class PromptService : IPromptService
 
     public string? PromptSelectDir(string title)
     {
-        var fileDialog = new CommonOpenFileDialog
+        var folderDialog = new FolderBrowserDialog
         {
             InitialDirectory = _appSettings.LastUsedDir,
-            Multiselect = false,
-            IsFolderPicker = true,
-            Title = title
+            Description = title
         };
 
-        if (fileDialog.ShowDialog(Application.Current.MainWindow) != CommonFileDialogResult.Ok)
+        if (folderDialog.ShowDialog() != DialogResult.OK)
             return null;
 
-        var dirPath = fileDialog.FileName;
+        var dirPath = folderDialog.SelectedPath;
 
         _appSettings.LastUsedDir = dirPath;
 
         return dirPath;
     }
 
-    public string? PromptSaveFile(string defaultFileName, string? title = null, IEnumerable<CommonFileDialogFilter>? filters = null)
+    public string? PromptSaveFile(string defaultFileName, string? title = null, string? filters = null)
     {
-        title ??= LocalizationManager.Instance.Current.Keys.SaveDialog_Title;
+        title ??= filters != null ? LocalizationManager.Instance.Current.Keys.SaveDialog_Title : LocalizationManager.Instance.Current.Keys.SaveDialog_AnyFileFilter;
         var sanitizedFileName = _fsSanitizer.SanitizeFileName(defaultFileName);
 
-        var fileDialog = new CommonSaveFileDialog
+        var fileDialog = new SaveFileDialog
         {
             Title = title,
             InitialDirectory = _appSettings.LastUsedDir,
-            DefaultFileName = sanitizedFileName,
+            FileName = sanitizedFileName,
+            Filter = filters
         };
 
-        if (filters == null)
-        {
 
-            fileDialog.Filters.Add(new CommonFileDialogFilter
-            {
-                DisplayName = LocalizationManager.Instance.Current.Keys.SaveDialog_AnyFileFilter,
-                ShowExtensions = false
-            });
-        }
-        else
-        {
-            foreach (var filter in filters)
-            {
-                fileDialog.Filters.Add(filter);
-            }
-        }
-
-
-        if (fileDialog.ShowDialog(Application.Current.MainWindow) != CommonFileDialogResult.Ok)
+        if (fileDialog.ShowDialog() != DialogResult.OK)
             return null;
 
         var filePath = fileDialog.FileName;


### PR DESCRIPTION
Fixes https://github.com/Myster-Tee/NxFileViewer/issues/20

From this:

![NxFileViewer-bug](https://github.com/Myster-Tee/NxFileViewer/assets/125513/380900ad-ec7d-494b-91e1-0c8a0a288f82)

To this:

![NxFileViewer-fixed](https://github.com/Myster-Tee/NxFileViewer/assets/125513/e23a8d5d-99b5-4dfb-a9d1-bb30c9015fd1)


I tested file extraction, image extraction, and folder extraction.  Compiled and ran locally using Microsoft Visual Studio Community 2022 (64-bit) on Windows 10.