### PR TITLE
Fix renaming NO_TITLE games

### DIFF
--- a/src/NxFileViewer/Services/FileRenaming/FileRenamerService.cs
+++ b/src/NxFileViewer/Services/FileRenaming/FileRenamerService.cs
@@ -235,7 +235,7 @@ public class FileRenamerService : IFileRenamerService
                             partValue = content.PatchTitleId;
                             break;
                         case PatternKeyword.TitleName:
-                            var firstTitle = content.NacpData?.Titles.FirstOrDefault();
+                            var firstTitle = content.NacpData?.Titles.FirstOrDefault(title => title != null && !string.IsNullOrEmpty(title.Name));
                             partValue = firstTitle != null ? firstTitle.Name : "NO_TITLE";
                             break;
                         case PatternKeyword.PackageType:


### PR DESCRIPTION
When renaming with pattern using Title, some games' name are set to "NO_TITLE" while they have actual name, for example in my case it's Aeterna Noctis (0100EB60159E4000).

From quick debug, I found that the parsed Titles also included null and empty items

<img width="958" alt="Screenshot 2024-02-13 103727" src="https://github.com/Myster-Tee/NxFileViewer/assets/22591362/f0687e47-1589-46ea-972d-faf453a5e313">


 I guess the root would be in the parsing method, but a temporary fix by checking null & empty when finding the first title name might work as well.