### PR TITLE
Support for Compression in 2.7.0

### DIFF
--- a/src/NxFileViewer/NxFileViewer.csproj
+++ b/src/NxFileViewer/NxFileViewer.csproj
@@ -13,7 +13,7 @@
     <Company>NxFileViewer</Company>
     <Product>NxFileViewer</Product>
     <Authors>NxFileViewer</Authors>
-    <Version>2.7.0</Version>
+    <Version>2.7.2</Version>
     <PackageProjectUrl></PackageProjectUrl>
     <PackageIcon>Icon.ico</PackageIcon>
     <Description>Browse content of Nintendo Switch files</Description>

--- a/src/NxFileViewer/NxFileViewer.csproj
+++ b/src/NxFileViewer/NxFileViewer.csproj
@@ -7,11 +7,13 @@
     <RootNamespace>Emignatik.NxFileViewer</RootNamespace>
     <Nullable>enable</Nullable>
     <ApplicationIcon>Styling\Icons\Icon.ico</ApplicationIcon>
+    <AssemblyVersion>2.7.0.2</AssemblyVersion>
+    <FileVersion>2.7.0.2</FileVersion>
     <PackageId>NxFileViewer</PackageId>
     <Company>NxFileViewer</Company>
     <Product>NxFileViewer</Product>
     <Authors>NxFileViewer</Authors>
-    <Version>2.7.1</Version>
+    <Version>2.7.0</Version>
     <PackageProjectUrl></PackageProjectUrl>
     <PackageIcon>Icon.ico</PackageIcon>
     <Description>Browse content of Nintendo Switch files</Description>

--- a/src/NxFileViewer/NxFileViewer.csproj
+++ b/src/NxFileViewer/NxFileViewer.csproj
@@ -11,7 +11,7 @@
     <Company>NxFileViewer</Company>
     <Product>NxFileViewer</Product>
     <Authors>NxFileViewer</Authors>
-    <Version>2.7.0</Version>
+    <Version>2.7.1</Version>
     <PackageProjectUrl></PackageProjectUrl>
     <PackageIcon>Icon.ico</PackageIcon>
     <Description>Browse content of Nintendo Switch files</Description>
@@ -44,11 +44,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1" />
     <PackageReference Include="LibHac" Version="0.19.0" />
     <PackageReference Include="Microsoft-WindowsAPICodePack-Shell" Version="1.1.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="ZstdSharp.Port" Version="0.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NxFileViewer/Services/BackgroundTask/RunnableImpl/VerifyNcasHashRunnable.cs
+++ b/src/NxFileViewer/Services/BackgroundTask/RunnableImpl/VerifyNcasHashRunnable.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Threading;
@@ -13,6 +14,12 @@ using LibHac.Fs.Fsa;
 using LibHac.Tools.FsSystem;
 using LibHac.Tools.Ncm;
 using Microsoft.Extensions.Logging;
+using ZstdSharp;
+
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Engines;
+using Org.BouncyCastle.Crypto.Modes;
+using Org.BouncyCastle.Crypto.Parameters;
 
 namespace Emignatik.NxFileViewer.Services.BackgroundTask.RunnableImpl;
 
@@ -114,7 +121,7 @@ public class VerifyNcasHashRunnable : IVerifyNcasHashRunnable
 
                     //=============================================//
                     //===============> Verify Hash <===============//
-                    VerifyFileHash(progressReporter, ncaItem.File, _appSettings.ProgressBufferSize, expectedNcaHash, cancellationToken, out var hashValid);
+                    VerifyFileHash(progressReporter, ncaItem.File, _appSettings.ProgressBufferSize, expectedNcaHash, cancellationToken, ncaItem.Name.ToLower().EndsWith(".ncz") ? true : false, out var hashValid);
                     //===============> Verify Hash <===============//
                     //=============================================//
 
@@ -169,8 +176,164 @@ public class VerifyNcasHashRunnable : IVerifyNcasHashRunnable
         }
 
     }
+    private static byte readInt8(Stream stream)
+    {
+        BinaryReader reader = new BinaryReader(stream);
+        return reader.ReadByte();
+    }
+    private static int ReadInt32(Stream stream)
+    {
+        BinaryReader reader = new BinaryReader(stream);
+        return reader.ReadInt32();
+    }
+    private static long ReadInt64(Stream stream)
+    {
+        BinaryReader reader = new BinaryReader(stream);
+        return reader.ReadInt64();
+    }
 
-    private static void VerifyFileHash(IProgressReporter progressReporter, IFile file, int bufferSize, IReadOnlyCollection<byte> expectedNcaHash, CancellationToken cancellationToken, out bool hashValid)
+
+    class Section
+    {
+        private Stream f;
+        public long offset;
+        public long size;
+        public long cryptoType;
+        private long padding;
+        public byte[] cryptoKey = new byte[16];
+        public byte[] cryptoCounter = new byte[16];
+        public Section(Stream file)
+        {
+            f = file;
+            offset = ReadInt64(f);
+            size = ReadInt64(f);
+            cryptoType = ReadInt64(f);
+            padding = ReadInt64(f);
+            file.Read(cryptoKey);
+            file.Read(cryptoCounter);
+        }
+    }
+
+    public class AESCTR
+    {
+        private readonly byte[] _key;
+        private readonly byte[] _nonce;
+        private byte[] _currentCtr;
+        private IBufferedCipher _cipher;
+
+        public AESCTR(byte[] key, byte[] nonce, int offset = 0)
+        {
+            _key = key;
+            _nonce = nonce;
+            Seek(offset);
+        }
+
+        public byte[] Encrypt(byte[] data)
+        {
+            _cipher.Init(true, new ParametersWithIV(new KeyParameter(_key), _currentCtr));
+            return _cipher.DoFinal(data);
+        }
+
+        public byte[] Decrypt(byte[] data)
+        {
+            return Encrypt(data); // In CTR mode, encrypt and decrypt are the same operation.
+        }
+
+        public void Seek(long offset)
+        {
+            byte[] iv = new byte[16];
+            Array.Copy(_nonce, 0, iv, 0, _nonce.Length); // Copy the nonce into the first 8 bytes.
+            byte[] offsetBytes = BitConverter.GetBytes(offset >> 4);
+            if (BitConverter.IsLittleEndian) // Convert to big-endian if necessary.
+                Array.Reverse(offsetBytes);
+            Array.Copy(offsetBytes, 0, iv, 8, offsetBytes.Length); // Copy the offset-derived bytes into the next 8 bytes.
+
+            _currentCtr = iv;
+
+            _cipher = new BufferedBlockCipher(new SicBlockCipher(new AesEngine()));
+            _cipher.Init(true, new ParametersWithIV(new KeyParameter(_key), iv));
+        }
+    }
+
+    private static bool VerifyNCZFileHash(IProgressReporter progressReporter, IFile file, long fileSize, IReadOnlyCollection<byte> expectedNcaHash, CancellationToken cancellationToken)
+    {
+        long ncaHeaderSize = 0x4000;
+        var nczStream = file.AsStream();
+        nczStream.Seek(0, SeekOrigin.Begin);
+        byte[] header = new byte[ncaHeaderSize];
+        nczStream.Read(header);
+        byte[] magic = new byte[8];
+        nczStream.Read(magic);
+
+        if (!magic.SequenceEqual(System.Text.Encoding.ASCII.GetBytes("NCZSECTN")))
+        {
+            throw new Exception("No NCZSECTN found! Is this really a .ncz file?");
+        }
+        long sectionCount = ReadInt64(nczStream);
+        var sections = new List<Section>();
+        for (int i = 0; i < sectionCount; i++)
+        {
+            sections.Add(new Section(nczStream));
+        }
+
+        long nca_size = ncaHeaderSize;
+        foreach (Section section in sections)
+        {
+            nca_size += section.size;
+        }
+
+        long pos = nczStream.Position;
+
+        byte[] blockMagic = new byte[8];
+        nczStream.Read(blockMagic);
+        nczStream.Seek(pos, SeekOrigin.Begin);
+
+        bool useBlockCompression = blockMagic.SequenceEqual(System.Text.Encoding.ASCII.GetBytes("NCZBLOCK"));
+        if (useBlockCompression)
+        {
+            throw new Exception("Not implemented");
+        }
+        pos = nczStream.Position;
+        var ncaStream = new DecompressionStream(nczStream);
+
+        IncrementalHash sha256 = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        sha256.AppendData(header);
+
+        foreach (Section s in sections)
+        {
+            long i = s.offset;
+            var crypto = new AESCTR(s.cryptoKey, s.cryptoCounter);
+            var end = s.offset + s.size;
+            while (i < end)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                crypto.Seek(i);
+                long chunkSz = end - i > 0x10000 ? 0x10000 : end - i;
+                if (useBlockCompression)
+                {
+                    throw new Exception("Not implemented");
+                }
+                else
+                {
+                    byte[] chunk = new byte[chunkSz];
+                    if (ncaStream.Read(chunk) == 0)
+                    {
+                        break;
+                    }
+                    if (s.cryptoType == 3 || s.cryptoType == 4) {
+                        chunk = crypto.Encrypt(chunk);
+                    }
+                    sha256.AppendData(chunk);
+                    progressReporter.SetPercentage(fileSize == 0 ? 0.0 : (double)(nczStream.Position / (double) fileSize));
+                    i += chunkSz;
+                }
+            }
+        }
+
+        var x = sha256.GetHashAndReset();
+        return x.SequenceEqual(expectedNcaHash);
+    }
+    private static void VerifyFileHash(IProgressReporter progressReporter, IFile file, int bufferSize, IReadOnlyCollection<byte> expectedNcaHash, CancellationToken cancellationToken, bool compressed, out bool hashValid)
     {
         if (file.GetSize(out var fileSize) != Result.Success)
             fileSize = 0;
@@ -178,11 +341,16 @@ public class VerifyNcasHashRunnable : IVerifyNcasHashRunnable
         var sha256 = SHA256.Create();
 
         var ncaStream = file.AsStream();
+        if (compressed)
+        {
+            hashValid = VerifyNCZFileHash(progressReporter, file, fileSize, expectedNcaHash, cancellationToken);
+            return;
+        }
         var buffer = new byte[bufferSize];
 
         decimal totalRead = 0;
         int read;
-        while ((read = ncaStream.Read(buffer, 0, buffer.Length)) > 0)
+        while ((read = ncaStream.Read(buffer)) > 0)
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/NxFileViewer/Services/FileRenaming/FileRenamerService.cs
+++ b/src/NxFileViewer/Services/FileRenaming/FileRenamerService.cs
@@ -235,7 +235,7 @@ public class FileRenamerService : IFileRenamerService
                             partValue = content.PatchTitleId;
                             break;
                         case PatternKeyword.TitleName:
-                            var firstTitle = content.NacpData?.Titles.FirstOrDefault();
+                            var firstTitle = content.NacpData?.Titles.FirstOrDefault(title => title != null && !string.IsNullOrEmpty(title.Name));
                             partValue = firstTitle != null ? firstTitle.Name : "NO_TITLE";
                             break;
                         case PatternKeyword.PackageType:


### PR DESCRIPTION
A hack job originally done by BestPig to support hash check in compressed files. Still throws an error about nca length being incorrect on compressed ncas. Otherwise, they still pass.