### PR TITLE
Renamer enhancement

### DIFF
--- a/src/NxFileViewer/Commands/ShowRenameToolWindowCommand.cs
+++ b/src/NxFileViewer/Commands/ShowRenameToolWindowCommand.cs
@@ -31,19 +31,20 @@ public class ShowRenameToolWindowCommand : CommandBase, IShowRenameToolWindowCom
 
         _renameToolWindow = new RenameToolWindow
         {
-            Owner = Application.Current.MainWindow,
+            Owner = Application.Current.MainWindow,            
         };
         _renameToolWindow.Closed += OnRenameToolWindowClosed;
         _renameToolWindow.DataContext = renameToolWindowViewModel;
         renameToolWindowViewModel.Window = _renameToolWindow;
-
         _renameToolWindow.Show();
+        Application.Current.MainWindow.Hide();
     }
 
     private void OnRenameToolWindowClosed(object? sender, EventArgs e)
     {
         _renameToolWindow = null;
         TriggerCanExecuteChanged();
+        Application.Current?.MainWindow?.Show();
     }
 }
 

--- a/src/NxFileViewer/Commands/ShowRenameToolWindowCommand.cs
+++ b/src/NxFileViewer/Commands/ShowRenameToolWindowCommand.cs
@@ -26,6 +26,8 @@ public class ShowRenameToolWindowCommand : CommandBase, IShowRenameToolWindowCom
         }
 
         var renameToolWindowViewModel = _serviceProvider.GetRequiredService<RenameToolWindowViewModel>();
+        var mainWindowViewModel = _serviceProvider.GetService<MainWindowViewModel>();
+        mainWindowViewModel?.CloseFileCommand.Execute(null);
 
         _renameToolWindow = new RenameToolWindow
         {

--- a/src/NxFileViewer/FileLoading/QuickFileInfoLoading/PackageInfo.cs
+++ b/src/NxFileViewer/FileLoading/QuickFileInfoLoading/PackageInfo.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Emignatik.NxFileViewer.Utils;
 using Emignatik.NxFileViewer.Utils.LibHacExtensions;
+using LibHac.Common;
 using LibHac.Ncm;
 using LibHac.Ns;
 using LibHac.Tools.FsSystem.NcaUtils;
@@ -60,12 +61,12 @@ public class Content
     {
         get
         {
-            U8Span _displayVersion = new U8Span("0");
+            String _displayVersion=String.Empty;
             if (NacpData != null)
             {
                 _displayVersion = NacpData.DisplayVersionString;
             }
-            return _displayVersion.ToString();
+            return _displayVersion;
         }
     }
 
@@ -101,11 +102,13 @@ public class NacpData
             mask <<= 1;
         }
 
+        DisplayVersionString = _applicationControlProperty.DisplayVersionString.ToString();
         Titles = titles;
     }
 
     public IReadOnlyList<Title?> Titles { get; }
 
+    public string DisplayVersionString = String.Empty;
 }
 
 public class Title

--- a/src/NxFileViewer/FileLoading/QuickFileInfoLoading/PackageInfo.cs
+++ b/src/NxFileViewer/FileLoading/QuickFileInfoLoading/PackageInfo.cs
@@ -56,6 +56,21 @@ public class Content
 
     public int PatchNumber => _cnmt.TitleVersion.GetPatchNumber();
 
+    public string DisplayVersion
+    {
+        get
+        {
+            U8Span _displayVersion = new U8Span("0");
+            if (NacpData != null)
+            {
+                _displayVersion = NacpData.DisplayVersionString;
+            }
+            return _displayVersion.ToString();
+        }
+    }
+
+    public string XCIUpdateVersion = "zzz";
+
 }
 
 public class NacpData

--- a/src/NxFileViewer/FileLoading/QuickFileInfoLoading/PackageInfo.cs
+++ b/src/NxFileViewer/FileLoading/QuickFileInfoLoading/PackageInfo.cs
@@ -69,7 +69,8 @@ public class Content
         }
     }
 
-    public string XCIUpdateVersion = "zzz";
+    public string XCIUpdateVersion = "-1";
+    public int AddonCount = 0;
 
 }
 

--- a/src/NxFileViewer/Localization/Keys/LocalizationKeys_EN.cs
+++ b/src/NxFileViewer/Localization/Keys/LocalizationKeys_EN.cs
@@ -332,8 +332,10 @@ public class LocalizationKeys_EN : LocalizationKeysBase, ILocalizationKeys
                                                    $"       - The content title retrieved from the Internet.{Environment.NewLine}" +
                                                    $"  • {{WAppTitle}}: {Environment.NewLine}" +
                                                    $"       - The title of the corresponding {nameof(ContentMetaType.Application)}, retrieved from the Internet.{Environment.NewLine}" +
-                                                   $"  • {{UpdateVer}}: {Environment.NewLine}" +
+                                                   $"  • {{DisplayVer}}: {Environment.NewLine}" +
                                                    $"       - The update display version of the corresponding {nameof(ContentMetaType.Application)}. {Environment.NewLine}" +
+                                                   $"  • {{XCIUpdateVer}}: {Environment.NewLine}" +
+                                                   $"       - The update XCIUpdate version of the corresponding {nameof(ContentMetaType.Application)}. {Environment.NewLine}" +
                                                    $"{Environment.NewLine}" +
                                                    $"Use \\{{ or \\}} to write the literal chars {{ or }}.";
     public string RenamingTool_ToolTip_BasePattern => $"The pattern to use for contents of type {nameof(ContentMetaType.Application)}.";

--- a/src/NxFileViewer/Localization/Keys/LocalizationKeys_EN.cs
+++ b/src/NxFileViewer/Localization/Keys/LocalizationKeys_EN.cs
@@ -332,6 +332,8 @@ public class LocalizationKeys_EN : LocalizationKeysBase, ILocalizationKeys
                                                    $"       - The content title retrieved from the Internet.{Environment.NewLine}" +
                                                    $"  • {{WAppTitle}}: {Environment.NewLine}" +
                                                    $"       - The title of the corresponding {nameof(ContentMetaType.Application)}, retrieved from the Internet.{Environment.NewLine}" +
+                                                   $"  • {{UpdateVer}}: {Environment.NewLine}" +
+                                                   $"       - The update display version of the corresponding {nameof(ContentMetaType.Application)}. {Environment.NewLine}" +
                                                    $"{Environment.NewLine}" +
                                                    $"Use \\{{ or \\}} to write the literal chars {{ or }}.";
     public string RenamingTool_ToolTip_BasePattern => $"The pattern to use for contents of type {nameof(ContentMetaType.Application)}.";

--- a/src/NxFileViewer/Services/FileRenaming/FileRenamerService.cs
+++ b/src/NxFileViewer/Services/FileRenaming/FileRenamerService.cs
@@ -222,7 +222,7 @@ public class FileRenamerService : IFileRenamerService
                     newFileName += staticText.Text;
                     break;
                 case DynamicTextPatternPart dynamicText:
-                    string partValue;
+                    string? partValue;
                     switch (dynamicText.Keyword)
                     {
                         case PatternKeyword.TitleId:
@@ -246,6 +246,9 @@ public class FileRenamerService : IFileRenamerService
                             break;
                         case PatternKeyword.PatchNumber:
                             partValue = content.PatchNumber.ToString();
+                            break;
+                        case PatternKeyword.DisplayVersion:
+                            partValue = content.NacpData?.DisplayVersionString.ToString();
                             break;
                         case PatternKeyword.OnlineTitleName:
                             var onlineTitleInfo = await _cachedOnlineTitleInfoService.GetTitleInfoAsync(content.TitleId);

--- a/src/NxFileViewer/Services/FileRenaming/Models/PatternParts/PatternKeyword.cs
+++ b/src/NxFileViewer/Services/FileRenaming/Models/PatternParts/PatternKeyword.cs
@@ -69,6 +69,12 @@ public enum PatternKeyword
     /// </summary>
     [SerializedValue("WAppTitle")]
     OnlineAppTitleName,
+
+    /// <summary>
+    /// The update display version number.
+    /// </summary>
+    [SerializedValue("UpdateVer")]
+    DisplayVersion,
 }
 
 public static class PatternKeywordHelper

--- a/src/NxFileViewer/Services/FileRenaming/Models/PatternParts/PatternKeyword.cs
+++ b/src/NxFileViewer/Services/FileRenaming/Models/PatternParts/PatternKeyword.cs
@@ -73,8 +73,14 @@ public enum PatternKeyword
     /// <summary>
     /// The update display version number.
     /// </summary>
-    [SerializedValue("UpdateVer")]
+    [SerializedValue("DisplayVer")]
     DisplayVersion,
+
+    /// <summary>
+    /// The update display version number.
+    /// </summary>
+    [SerializedValue("XCIUpdateVer")]
+    XCIUpdateVersion,
 }
 
 public static class PatternKeywordHelper

--- a/src/NxFileViewer/Settings/AppSettings.cs
+++ b/src/NxFileViewer/Settings/AppSettings.cs
@@ -189,8 +189,8 @@ public class RenamingOptions : NotifyPropertyChangedBase, IRenamingOptions
 {
     private string? _fileFilters = "*.nsp;*.nsz;*.xci;*.xcz";
     private bool _includeSubdirectories = true;
-    private string _applicationPattern = "{WAppTitle} [{TitleId:U}][v{PatchNum}].{Ext:L}";
-    private string _patchPattern = "{WAppTitle} [{TitleId:U}][v{PatchNum}].{Ext:L}";
+    private string _applicationPattern = "{WAppTitle} [{TitleId:U}][v{VerNum}]+[u{XCIUpdateVer}].{Ext:L}";
+    private string _patchPattern = "{WAppTitle} [{TitleId:U}][v{PatchNum}][u{DisplayVer}].{Ext:L}";
     private string _addonPattern = "{WAppTitle} - {WTitle} [{TitleId:U}][v{PatchNum}].{Ext:L}";
     private bool _isSimulation = true;
     private string _invalidFileNameCharsReplacement = "꞉";

--- a/src/NxFileViewer/Views/Windows/RenameToolWindow.xaml
+++ b/src/NxFileViewer/Views/Windows/RenameToolWindow.xaml
@@ -12,14 +12,14 @@
         mc:Ignorable="d"
         Style="{StaticResource WindowStyle}"
         Title="{Binding Source={x:Static loc:LocalizationManager.Instance}, Path=Current.Keys.RenamingTool_WindowTitle}" 
-        Height="400"
-        Width="380"
+        Height="900"
+        Width="1400"
         d:DataContext="{d:DesignInstance windows:RenameToolWindowViewModel}">
 
     <Grid>
 
         <Grid.RowDefinitions>
-            <RowDefinition Height="2*" />
+            <RowDefinition Height=".5*" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
@@ -55,7 +55,7 @@
                             <TextBox Grid.Row="1" Grid.Column="0" Text="{Binding Path=RenameCommand.FileFilters}" VerticalAlignment="Center" />
                             <CheckBox Grid.Row="1" Grid.Column="1" Content="{Binding Source={x:Static loc:LocalizationManager.Instance}, Path=Current.Keys.RenamingTool_IncludeSubDirectories}" 
                               IsChecked="{Binding Path=RenameCommand.IncludeSubdirectories}"
-                              HorizontalAlignment="Center" VerticalAlignment="Center" />
+                              HorizontalAlignment="Right" VerticalAlignment="Center" />
                         </Grid>
                     </StackPanel>
                 </GroupBox>
@@ -182,7 +182,7 @@
             <userControls:LoggingView HorizontalAlignment="Stretch" VerticalAlignment="Stretch" LogSource="{Binding LogSource, Mode=OneWay}" />
         </GroupBox>
 
-        <StackPanel Grid.Row="3" Orientation="Horizontal" Height="30" HorizontalAlignment="Center" Margin="0,5">
+        <StackPanel Grid.Row="3" Orientation="Horizontal" Height="30" HorizontalAlignment="Right" Margin="0,5">
             <CheckBox Content="{Binding Source={x:Static loc:LocalizationManager.Instance}, Path=Current.Keys.RenamingTool_Simulation}" VerticalAlignment="Center" IsChecked="{Binding Path=RenameCommand.IsSimulation}" 
                       Style="{StaticResource TextOnLeft}" />
 

--- a/src/NxFileViewer/Views/Windows/RenameToolWindow.xaml
+++ b/src/NxFileViewer/Views/Windows/RenameToolWindow.xaml
@@ -12,8 +12,8 @@
         mc:Ignorable="d"
         Style="{StaticResource WindowStyle}"
         Title="{Binding Source={x:Static loc:LocalizationManager.Instance}, Path=Current.Keys.RenamingTool_WindowTitle}" 
-        Height="900"
-        Width="1400"
+        Height="600"
+        Width="800"
         d:DataContext="{d:DesignInstance windows:RenameToolWindowViewModel}">
 
     <Grid>


### PR DESCRIPTION
- added support for DisplayVer (in UI term), in code UpdateVer
- added support for XCIUpdateVer for xci type. 
- updated default pattern string accordingly
- press 'F2' on main UI, closes any opened file, hide main window and opens up renamer window (this keeps 'file locked' from happening' 
- resized renamer window to bigger 800x600 size (easy to preview)
- extra clean up for special chars "™", "©", "®", in file name. 
- included no_titles fix (when multiple packages are in xci and application != first package)