### PR TITLE
Updated NuGet packages and changed tinfoil.media to tinfoil.io

### DIFF
--- a/src/LibHac.NSZ.Test/LibHac.NSZ.Test.csproj
+++ b/src/LibHac.NSZ.Test/LibHac.NSZ.Test.csproj
@@ -10,13 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/LibHac.NSZ/LibHac.NSZ.csproj
+++ b/src/LibHac.NSZ/LibHac.NSZ.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="LibHac" Version="0.19.0" />
-    <PackageReference Include="ZstdSharp.Port" Version="0.8.4" />
+    <PackageReference Include="ZstdSharp.Port" Version="0.8.7" />
   </ItemGroup>
 
 </Project>

--- a/src/NxFileViewer.Test/NxFileViewer.Test.csproj
+++ b/src/NxFileViewer.Test/NxFileViewer.Test.csproj
@@ -8,13 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/NxFileViewer/NxFileViewer.csproj
+++ b/src/NxFileViewer/NxFileViewer.csproj
@@ -47,9 +47,9 @@
   <ItemGroup>
     <PackageReference Include="LibHac" Version="0.19.0" />
     <PackageReference Include="Microsoft-WindowsAPICodePack-Shell" Version="1.1.5" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NxFileViewer/Settings/AppSettings.cs
+++ b/src/NxFileViewer/Settings/AppSettings.cs
@@ -17,8 +17,8 @@ public class AppSettings : NotifyPropertyChangedBase, IAppSettings
     private string _titleKeysDownloadUrl = "";
     private bool _alwaysReloadKeysBeforeOpen = false;
 
-    private string _titlePageUrl = "https://tinfoil.media/Title/{TitleId}";
-    private string _titleInfoApiUrl = "https://tinfoil.media/api/title/{TitleId}";
+    private string _titlePageUrl = "https://tinfoil.io/Title/{TitleId}";
+    private string _titleInfoApiUrl = "https://tinfoil.io/api/title/{TitleId}";
     private string _lastUsedDir = "";
     private bool _allowNczBlocklessCompressionOpening = true;
     private bool _acceptMissingDeltaFragments = true;


### PR DESCRIPTION
xunit has been deprecated and replaced with xunit.v3
I have also changed the two mentions of tinfoil.media to tinfoil.io as the latter is the main website.