### PR TITLE
Support Compressed Title Block for control.nacp

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Build (win-x64 / win-x86)
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Publish
+        shell: pwsh
+        run: ./Publish.ps1
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: NxFileViewer-build
+          path: Publish/*.zip
+          if-no-files-found: error
+          retention-days: 7

--- a/src/NxFileViewer/Models/Overview/NacpLanguage.cs
+++ b/src/NxFileViewer/Models/Overview/NacpLanguage.cs
@@ -3,25 +3,49 @@
 namespace Emignatik.NxFileViewer.Models.Overview;
 
 /// <summary>
-/// Base on "https://switchbrew.org/wiki/ControlPartition.nacp#Title_Entry"
+/// Based on "https://switchbrew.org/wiki/ControlPartition.nacp#Title_Entry"
+/// Values 0–15 correspond to LibHac's NacpLanguage enum and the legacy uncompressed NACP format.
+/// Values 16+ are extended languages present only in the compressed title block introduced in newer firmware.
 /// </summary>
 [Flags]
 public enum NacpLanguage : uint
 {
-    AmericanEnglish = 0,
-    BritishEnglish = 1,
-    Japanese = 2,
-    French = 3,
-    German = 4,
+    AmericanEnglish      = 0,
+    BritishEnglish       = 1,
+    Japanese             = 2,
+    French               = 3,
+    German               = 4,
     LatinAmericanSpanish = 5,
-    Spanish = 6,
-    Italian = 7,
-    Dutch = 8,
-    CanadianFrench = 9,
-    Portuguese = 10,
-    Russian = 11,
-    Korean = 12,
-    TraditionalChinese = 13, // SwitchBrew specifies "Taiwanese" but it seems to be "TraditionalChinese"
-    SimplifiedChinese = 14, // SwitchBrew specifies "Chinese" but it seems to be "SimplifiedChinese"
-    BrazilianPortuguese = 15,
+    Spanish              = 6,
+    Italian              = 7,
+    Dutch                = 8,
+    CanadianFrench       = 9,
+    Portuguese           = 10,
+    Russian              = 11,
+    Korean               = 12,
+    TraditionalChinese   = 13, // SwitchBrew specifies "Taiwanese" but it seems to be "TraditionalChinese"
+    SimplifiedChinese    = 14, // SwitchBrew specifies "Chinese" but it seems to be "SimplifiedChinese"
+    BrazilianPortuguese  = 15,
+
+    // Extended languages — present only in the new compressed NACP title block format
+    Polish               = 16,
+    Thai                 = 17,
+    Indonesian           = 18,
+    Romanian             = 19,
+    Vietnamese           = 20,
+    Arabic               = 21,
+    Ukrainian            = 22,
+    Czech                = 23,
+    Slovak               = 24,
+    Greek                = 25,
+    Hungarian            = 26,
+    Norwegian            = 27,
+    Finnish              = 28,
+    Swedish              = 29,
+    Danish               = 30,
 }
+
+/// <summary>
+/// A name/publisher pair for a single NACP language entry.
+/// </summary>
+public record NacpTitleEntry(string Name, string Publisher);

--- a/src/NxFileViewer/Models/Overview/TitleInfo.cs
+++ b/src/NxFileViewer/Models/Overview/TitleInfo.cs
@@ -4,17 +4,34 @@ namespace Emignatik.NxFileViewer.Models.Overview;
 
 public class TitleInfo
 {
-    private readonly ApplicationControlProperty.ApplicationTitle _applicationTitle;
+    private readonly string _appName;
+    private readonly string _publisher;
 
+    /// <summary>
+    /// Constructor for the 16 legacy languages sourced from LibHac's
+    /// <c>ApplicationControlProperty.ApplicationTitle</c> struct.
+    /// </summary>
     public TitleInfo(ref ApplicationControlProperty.ApplicationTitle applicationTitle, NacpLanguage language)
     {
-        _applicationTitle = applicationTitle;
-        Language = language;
+        _appName   = applicationTitle.NameString.ToString();
+        _publisher = applicationTitle.PublisherString.ToString();
+        Language   = language;
     }
 
-    public string AppName => _applicationTitle.NameString.ToString();
+    /// <summary>
+    /// Constructor for extended languages (index 16+) sourced from the compressed
+    /// NACP title block, where title data is provided as plain strings.
+    /// </summary>
+    public TitleInfo(NacpTitleEntry titleEntry, NacpLanguage language)
+    {
+        _appName   = titleEntry.Name;
+        _publisher = titleEntry.Publisher;
+        Language   = language;
+    }
 
-    public string Publisher => _applicationTitle.PublisherString.ToString();
+    public string AppName => _appName;
+
+    public string Publisher => _publisher;
 
     public NacpLanguage Language { get; }
 
@@ -22,10 +39,11 @@ public class TitleInfo
 
     public override string ToString()
     {
-        var appName = AppName;
+        var appName   = AppName;
         var publisher = Publisher;
 
-        if (string.IsNullOrWhiteSpace(appName) && string.IsNullOrWhiteSpace(publisher)) return "";
+        if (string.IsNullOrWhiteSpace(appName) && string.IsNullOrWhiteSpace(publisher))
+            return "";
 
         var publisherStr = string.IsNullOrEmpty(publisher) ? "" : $" - {publisher}";
         return $"{appName}{publisherStr} ({Language})";

--- a/src/NxFileViewer/Models/TreeItems/Impl/NacpItem.cs
+++ b/src/NxFileViewer/Models/TreeItems/Impl/NacpItem.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
+using Emignatik.NxFileViewer.Models.Overview;
 using Emignatik.NxFileViewer.Utils;
+using Emignatik.NxFileViewer.Utils.LibHacExtensions;
 using LibHac.Ns;
 using LibHac.Tools.Fs;
 
@@ -9,19 +12,33 @@ public class NacpItem : DirectoryEntryItem
 {
     public const string NACP_FILE_NAME = "control.nacp";
 
-    public NacpItem(ApplicationControlProperty nacp, SectionItem parentItem, DirectoryEntryEx directoryEntry) : base(parentItem, directoryEntry)
+    public NacpItem(
+        ApplicationControlProperty nacp,
+        SectionItem parentItem,
+        DirectoryEntryEx directoryEntry,
+        IReadOnlyDictionary<NacpLanguage, NacpTitleEntry>? extendedTitleEntries = null)
+        : base(parentItem, directoryEntry)
     {
         Nacp = nacp;
         ParentItem = parentItem ?? throw new ArgumentNullException(nameof(parentItem));
         AddOnContentBaseId = Nacp.AddOnContentBaseId.ToStrId();
         PresenceGroupId = Nacp.PresenceGroupId.ToStrId();
         SaveDataOwnerId = Nacp.SaveDataOwnerId.ToStrId();
+        ExtendedTitleEntries = extendedTitleEntries
+            ?? new Dictionary<NacpLanguage, NacpTitleEntry>();
     }
-
 
     public new SectionItem ParentItem { get; }
 
     public ApplicationControlProperty Nacp { get; }
+
+    /// <summary>
+    /// Title entries for languages beyond the 16 supported by LibHac's
+    /// <c>ApplicationControlProperty</c> struct (Polish, Thai, etc.).
+    /// Only languages with a non-empty name are present.
+    /// Keyed by the <see cref="NacpLanguage"/> value (index 16+).
+    /// </summary>
+    public IReadOnlyDictionary<NacpLanguage, NacpTitleEntry> ExtendedTitleEntries { get; }
 
     public override string Format => nameof(Nacp);
 
@@ -32,7 +49,7 @@ public class NacpItem : DirectoryEntryItem
     public ApplicationControlProperty.AddOnContentRegistrationTypeValue AddOnContentRegistrationType => Nacp.AddOnContentRegistrationType;
 
     public ApplicationControlProperty.AttributeFlagValue Attribute => Nacp.AttributeFlag;
-    
+
     public ApplicationControlProperty.ParentalControlFlagValue ParentalControl => Nacp.ParentalControlFlag;
 
     public ApplicationControlProperty.ScreenshotValue Screenshot => Nacp.Screenshot;
@@ -46,7 +63,7 @@ public class NacpItem : DirectoryEntryItem
     public string PresenceGroupId { get; }
 
     public string DisplayVersion => Nacp.DisplayVersionString.ToString();
-    
+
     public string AddOnContentBaseId { get; }
 
     public string SaveDataOwnerId { get; }
@@ -58,9 +75,8 @@ public class NacpItem : DirectoryEntryItem
     public ApplicationControlProperty.LogoHandlingValue LogoHandling => Nacp.LogoHandling;
 
     public ApplicationControlProperty.StartupUserAccountOptionFlagValue StartupUserAccountOption => Nacp.StartupUserAccountOption;
-    
-    public string Isbn => Nacp.IsbnString.ToString();
-    
-    public string BcatPassphrase => Nacp.BcatPassphraseString.ToString();
 
+    public string Isbn => Nacp.IsbnString.ToString();
+
+    public string BcatPassphrase => Nacp.BcatPassphraseString.ToString();
 }

--- a/src/NxFileViewer/NxFileViewer.csproj
+++ b/src/NxFileViewer/NxFileViewer.csproj
@@ -11,7 +11,7 @@
     <Company>NxFileViewer</Company>
     <Product>NxFileViewer</Product>
     <Authors>NxFileViewer</Authors>
-    <Version>3.0.2</Version>
+    <Version>3.0.3</Version>
     <PackageProjectUrl></PackageProjectUrl>
     <PackageIcon>Icon.ico</PackageIcon>
     <Description>Browse content of Nintendo Switch files</Description>

--- a/src/NxFileViewer/Utils/LibHacExtensions/NacpTitleBlockDecompressor.cs
+++ b/src/NxFileViewer/Utils/LibHacExtensions/NacpTitleBlockDecompressor.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using Emignatik.NxFileViewer.Models.Overview;
+
+namespace Emignatik.NxFileViewer.Utils.LibHacExtensions;
+
+/// <summary>
+/// Handles decompression of the NACP title block introduced in a newer Switch firmware.
+///
+/// Legacy NACP format:
+///   [0x0000 – 0x2FFF]  16 × NacpLanguageEntry (each 0x300 bytes: 0x200 name + 0x100 author)
+///   [0x3000 – 0x3FFF]  Metadata fields
+///
+/// New compressed format (flag byte at 0x3215 != 0):
+///   [0x0000 – 0x2FFF]  Compressed title block:
+///                          u16 LE  compressed_size
+///                          u8[]    compressed_data[compressed_size]  (raw DEFLATE, wbits=-15)
+///   [0x3000 – 0x3FFF]  Metadata fields  (unchanged, uncompressed)
+///
+/// The compressed data decompresses to up to 32 NacpLanguageEntry blocks (0x300 bytes each).
+/// Indices 0–15 map to <see cref="NacpLanguage"/> values 0–15 (legacy languages).
+/// Indices 16–30 map to the extended <see cref="NacpLanguage"/> values added in newer firmware.
+/// </summary>
+internal static class NacpTitleBlockDecompressor
+{
+    private const int TitleBlockSize  = 0x3000;
+    private const int MetadataOffset  = 0x3000;
+    private const int FlagOffset      = 0x3215;
+    private const int EntrySize       = 0x300;
+    private const int NameSize        = 0x200;
+    private const int PublisherSize   = 0x100;
+    private const int LegacyLangCount = 16;
+
+    /// <summary>
+    /// Returns true when the raw NACP bytes use the new compressed title block format.
+    /// </summary>
+    public static bool IsCompressed(ReadOnlySpan<byte> nacpBytes)
+        => nacpBytes.Length > FlagOffset && nacpBytes[FlagOffset] != 0;
+
+    /// <summary>
+    /// If the buffer uses the new compressed format, decompresses the title block and returns
+    /// a new byte array whose first 0x3000 bytes are the first 16 language entries (compatible
+    /// with LibHac's <c>ApplicationControlProperty</c> struct), followed by the original
+    /// metadata section verbatim.  If already legacy format, returns a copy unchanged.
+    /// </summary>
+    public static byte[] DecompressIfNeeded(ReadOnlySpan<byte> nacpBytes)
+    {
+        if (!IsCompressed(nacpBytes))
+            return nacpBytes.ToArray();
+
+        var decompressed = Decompress(nacpBytes);
+
+        int metaLen = Math.Max(0, nacpBytes.Length - MetadataOffset);
+        byte[] result = new byte[TitleBlockSize + metaLen];
+
+        decompressed.AsSpan(0, TitleBlockSize).CopyTo(result);
+
+        if (metaLen > 0)
+            nacpBytes.Slice(MetadataOffset, metaLen).CopyTo(result.AsSpan(TitleBlockSize));
+
+        return result;
+    }
+
+    /// <summary>
+    /// Returns title entries for extended languages (index 16+) present in the compressed
+    /// title block, keyed by their <see cref="NacpLanguage"/> value.
+    /// Returns an empty dictionary for legacy uncompressed NACPs.
+    /// Only entries with a non-empty name are included.
+    /// </summary>
+    public static IReadOnlyDictionary<NacpLanguage, NacpTitleEntry> GetExtendedTitleEntries(ReadOnlySpan<byte> rawNacpBytes)
+    {
+        var result = new Dictionary<NacpLanguage, NacpTitleEntry>();
+
+        if (!IsCompressed(rawNacpBytes))
+            return result;
+
+        byte[] decompressed;
+        try
+        {
+            decompressed = Decompress(rawNacpBytes);
+        }
+        catch (InvalidDataException)
+        {
+            return result;
+        }
+
+        int totalEntries = decompressed.Length / EntrySize;
+
+        foreach (NacpLanguage lang in Enum.GetValues<NacpLanguage>())
+        {
+            int index = (int)lang;
+            if (index < LegacyLangCount || index >= totalEntries)
+                continue;
+
+            int offset       = index * EntrySize;
+            string name      = Encoding.UTF8.GetString(decompressed, offset, NameSize).TrimEnd('\0');
+            string publisher = Encoding.UTF8.GetString(decompressed, offset + NameSize, PublisherSize).TrimEnd('\0');
+
+            if (!string.IsNullOrEmpty(name))
+                result[lang] = new NacpTitleEntry(name, publisher);
+        }
+
+        return result;
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────────────────────
+
+    private static byte[] Decompress(ReadOnlySpan<byte> nacpBytes)
+    {
+        if (nacpBytes.Length < 2)
+            throw new InvalidDataException("NACP buffer too small to contain compressed title block header.");
+
+        ushort compressedSize = (ushort)(nacpBytes[0] | (nacpBytes[1] << 8));
+        int dataStart = 2;
+        int dataEnd   = dataStart + compressedSize;
+
+        if (dataEnd > MetadataOffset)
+            throw new InvalidDataException(
+                $"NACP compressed_size (0x{compressedSize:X}) causes compressed data " +
+                $"(ends at 0x{dataEnd:X}) to overflow the title block region (0x{MetadataOffset:X}).");
+
+        try
+        {
+            using var input   = new MemoryStream(nacpBytes.Slice(dataStart, compressedSize).ToArray());
+            using var deflate = new DeflateStream(input, CompressionMode.Decompress);
+            using var output  = new MemoryStream(TitleBlockSize);
+            deflate.CopyTo(output);
+            byte[] decompressed = output.ToArray();
+
+            if (decompressed.Length < TitleBlockSize)
+                throw new InvalidDataException(
+                    $"Decompressed NACP title block is 0x{decompressed.Length:X} bytes; " +
+                    $"expected at least 0x{TitleBlockSize:X}.");
+
+            return decompressed;
+        }
+        catch (Exception ex) when (ex is not InvalidDataException)
+        {
+            throw new InvalidDataException("Failed to decompress NACP title block.", ex);
+        }
+    }
+}

--- a/src/NxFileViewer/Views/Converters/NacpLanguageConverter.cs
+++ b/src/NxFileViewer/Views/Converters/NacpLanguageConverter.cs
@@ -12,23 +12,41 @@ public class NacpLanguageConverter : ValueConverterBase<string, NacpLanguage>
     {
         return value switch
         {
-            NacpLanguage.AmericanEnglish => LocalizationManager.Instance.Current.Keys.Lng_AmericanEnglish,
-            NacpLanguage.BritishEnglish => LocalizationManager.Instance.Current.Keys.Lng_BritishEnglish,
-            NacpLanguage.Japanese => LocalizationManager.Instance.Current.Keys.Lng_Japanese,
-            NacpLanguage.French => LocalizationManager.Instance.Current.Keys.Lng_French,
-            NacpLanguage.German => LocalizationManager.Instance.Current.Keys.Lng_German,
+            NacpLanguage.AmericanEnglish      => LocalizationManager.Instance.Current.Keys.Lng_AmericanEnglish,
+            NacpLanguage.BritishEnglish       => LocalizationManager.Instance.Current.Keys.Lng_BritishEnglish,
+            NacpLanguage.Japanese             => LocalizationManager.Instance.Current.Keys.Lng_Japanese,
+            NacpLanguage.French               => LocalizationManager.Instance.Current.Keys.Lng_French,
+            NacpLanguage.German               => LocalizationManager.Instance.Current.Keys.Lng_German,
             NacpLanguage.LatinAmericanSpanish => LocalizationManager.Instance.Current.Keys.Lng_LatinAmericanSpanish,
-            NacpLanguage.Spanish => LocalizationManager.Instance.Current.Keys.Lng_Spanish,
-            NacpLanguage.Italian => LocalizationManager.Instance.Current.Keys.Lng_Italian,
-            NacpLanguage.Dutch => LocalizationManager.Instance.Current.Keys.Lng_Dutch,
-            NacpLanguage.CanadianFrench => LocalizationManager.Instance.Current.Keys.Lng_CanadianFrench,
-            NacpLanguage.Portuguese => LocalizationManager.Instance.Current.Keys.Lng_Portuguese,
-            NacpLanguage.Russian => LocalizationManager.Instance.Current.Keys.Lng_Russian,
-            NacpLanguage.Korean => LocalizationManager.Instance.Current.Keys.Lng_Korean,
-            NacpLanguage.TraditionalChinese => LocalizationManager.Instance.Current.Keys.Lng_TraditionalChinese,
-            NacpLanguage.SimplifiedChinese => LocalizationManager.Instance.Current.Keys.Lng_SimplifiedChinese,
-            NacpLanguage.BrazilianPortuguese => LocalizationManager.Instance.Current.Keys.Lng_BrazilianPortuguese,
-            _ => LocalizationManager.Instance.Current.Keys.Lng_Unknown
+            NacpLanguage.Spanish              => LocalizationManager.Instance.Current.Keys.Lng_Spanish,
+            NacpLanguage.Italian              => LocalizationManager.Instance.Current.Keys.Lng_Italian,
+            NacpLanguage.Dutch                => LocalizationManager.Instance.Current.Keys.Lng_Dutch,
+            NacpLanguage.CanadianFrench       => LocalizationManager.Instance.Current.Keys.Lng_CanadianFrench,
+            NacpLanguage.Portuguese           => LocalizationManager.Instance.Current.Keys.Lng_Portuguese,
+            NacpLanguage.Russian              => LocalizationManager.Instance.Current.Keys.Lng_Russian,
+            NacpLanguage.Korean               => LocalizationManager.Instance.Current.Keys.Lng_Korean,
+            NacpLanguage.TraditionalChinese   => LocalizationManager.Instance.Current.Keys.Lng_TraditionalChinese,
+            NacpLanguage.SimplifiedChinese    => LocalizationManager.Instance.Current.Keys.Lng_SimplifiedChinese,
+            NacpLanguage.BrazilianPortuguese  => LocalizationManager.Instance.Current.Keys.Lng_BrazilianPortuguese,
+
+            // Extended languages — no localization keys yet, use readable name directly
+            NacpLanguage.Polish               => "Polish",
+            NacpLanguage.Thai                 => "Thai",
+            NacpLanguage.Indonesian           => "Indonesian",
+            NacpLanguage.Romanian             => "Romanian",
+            NacpLanguage.Vietnamese           => "Vietnamese",
+            NacpLanguage.Arabic               => "Arabic",
+            NacpLanguage.Ukrainian            => "Ukrainian",
+            NacpLanguage.Czech                => "Czech",
+            NacpLanguage.Slovak               => "Slovak",
+            NacpLanguage.Greek                => "Greek",
+            NacpLanguage.Hungarian            => "Hungarian",
+            NacpLanguage.Norwegian            => "Norwegian",
+            NacpLanguage.Finnish              => "Finnish",
+            NacpLanguage.Swedish              => "Swedish",
+            NacpLanguage.Danish               => "Danish",
+
+            _                                 => LocalizationManager.Instance.Current.Keys.Lng_Unknown
         };
     }
 


### PR DESCRIPTION
bump to 3.0.3
added support for control.nacp with compressed Title Block which now supports 32 languages up from 16. I believe I covered all the bases. Thanks to Liam for the info!